### PR TITLE
RecurrentUNet Initial Implementation

### DIFF
--- a/confnets/layers/recurrent.py
+++ b/confnets/layers/recurrent.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class ConvGRUCell(nn.Module):
@@ -41,9 +40,9 @@ class ConvGRUCell(nn.Module):
 
         # data size is [batch, channel, height, width]
         stacked_inputs = torch.cat([input_, self.hidden_state], dim=1)
-        update = F.sigmoid(self.update_gate(stacked_inputs))
-        reset = F.sigmoid(self.reset_gate(stacked_inputs))
-        out_inputs = F.tanh(self.out_gate(torch.cat([input_, self.hidden_state * reset], dim=1)))
+        update = torch.sigmoid(self.update_gate(stacked_inputs))
+        reset = torch.sigmoid(self.reset_gate(stacked_inputs))
+        out_inputs = torch.tanh(self.out_gate(torch.cat([input_, self.hidden_state * reset], dim=1)))
         self.hidden_state = self.hidden_state * (1 - update) + out_inputs * update
 
         return self.hidden_state

--- a/confnets/layers/recurrent.py
+++ b/confnets/layers/recurrent.py
@@ -10,8 +10,11 @@ class ConvGRUCell(nn.Module):
         """
         Generate a convolutional GRU cell
 
-        :param invert_update_gate:
-        :param out_gate_activation:
+        :param invert_update_gate: Change update to 1-update (invert update gate output)
+        when setting the new hidden state. Default is False, and follows the commonly 
+        accepted update equations for GRU.
+        :param out_gate_activation: Callable, function to apply as activation to the out
+        gate. Default is tanh.
         """
         super(ConvGRUCell, self).__init__()
         self.input_size = input_size

--- a/confnets/layers/recurrent.py
+++ b/confnets/layers/recurrent.py
@@ -12,11 +12,11 @@ class ConvGRUCell(nn.Module):
         super(ConvGRUCell, self).__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
-        # padding = kernel_size // 2
+        padding = kernel_size // 2
         hs = hidden_size
-        self.reset_gate = conv_type(input_size + hs, hs, kernel_size)
-        self.update_gate = conv_type(input_size + hs, hs, kernel_size)
-        self.out_gate = conv_type(input_size + hs, hs, kernel_size)
+        self.reset_gate = conv_type(input_size + hs, hs, kernel_size, padding=padding)
+        self.update_gate = conv_type(input_size + hs, hs, kernel_size, padding=padding)
+        self.out_gate = conv_type(input_size + hs, hs, kernel_size, padding=padding)
 
         # Initial hidden state
         self.hidden_state = None

--- a/confnets/layers/recurrent.py
+++ b/confnets/layers/recurrent.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 
 class ConvGRUCell(nn.Module):
@@ -17,6 +18,9 @@ class ConvGRUCell(nn.Module):
         self.update_gate = conv_type(input_size + hs, hs, kernel_size)
         self.out_gate = conv_type(input_size + hs, hs, kernel_size)
 
+        # Initial hidden state
+        self.hidden_state = None
+
         # init.orthogonal(self.reset_gate.weight)
         # init.orthogonal(self.update_gate.weight)
         # init.orthogonal(self.out_gate.weight)
@@ -24,25 +28,25 @@ class ConvGRUCell(nn.Module):
         # init.constant(self.update_gate.bias, 0.)
         # init.constant(self.out_gate.bias, 0.)
 
-    def forward(self, input_, prev_state):
+    def forward(self, input_):
 
         # get batch and spatial sizes
         batch_size = input_.data.size()[0]
         spatial_size = input_.data.size()[2:]
 
-        # generate empty prev_state, if None is provided
-        if prev_state is None:
+        # generate hidden state of zeros, if currently None
+        if self.hidden_state is None:
             state_size = [batch_size, self.hidden_size] + list(spatial_size)
-            prev_state = input_.new(np.zeros(state_size))
+            self.hidden_state = input_.new(torch.zeros(state_size))
 
         # data size is [batch, channel, height, width]
-        stacked_inputs = torch.cat([input_, prev_state], dim=1)
+        stacked_inputs = torch.cat([input_, self.hidden_state], dim=1)
         update = F.sigmoid(self.update_gate(stacked_inputs))
         reset = F.sigmoid(self.reset_gate(stacked_inputs))
-        out_inputs = F.tanh(self.out_gate(torch.cat([input_, prev_state * reset], dim=1)))
-        new_state = prev_state * (1 - update) + out_inputs * update
+        out_inputs = F.tanh(self.out_gate(torch.cat([input_, self.hidden_state * reset], dim=1)))
+        self.hidden_state = self.hidden_state * (1 - update) + out_inputs * update
 
-        return new_state
+        return self.hidden_state
 
 
 class ConvGRU(nn.Module):
@@ -107,14 +111,14 @@ class ConvGRU(nn.Module):
             time_index = batch * sl
 
             for idx in range(self.n_layers):
-                upd_cell_hidden = self.cells[idx](input_[time_index:time_index + 1], None).detach()
+                upd_cell_hidden = self.cells[idx](input_[time_index:time_index + 1]).detach()
 
             for s in range(self.sequence_length):
                 x = input_[time_index + s:time_index + s + 1]
                 for layer_idx in range(self.n_layers):
                     cell = self.cells[layer_idx]
                     # pass through layer
-                    upd_cell_hidden = cell(x, upd_cell_hidden)
+                    upd_cell_hidden = cell(x)
 
                 upd_hidden.append(upd_cell_hidden)
 


### PR DESCRIPTION
I welcome any suggestions for improvement!

* forward() still a work in progress
* Should the forward() function work on (batch, channel, x, y) or (batch, channel, t, x, y)? The latter would more explicitly point the user that the network is meant to work on sequential data.
* Note: Is batching supposed to somehow work with the ConvGRUs? The way I see it, each member of a sequence has to be .forward-ed individually through the recurrent modules, which means we cannot use batches. Or am I wrong?